### PR TITLE
Tar gz support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wolkenatlas"
-version = "0.1.4"
+version = "0.1.5"
 authors = [
   { name="Thomas Kober", email="tttthomasssss@gmail.com" },
 ]

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
 	# Versions should comply with PEP440.  For a discussion on single-sourcing
 	# the version across setup.py and the project code, see
 	# https://packaging.python.org/en/latest/single_source_version.html
-	version='0.1.4',
+	version='0.1.5',
 
 	description='NLP embedding wrapper',
 	long_description=long_description,

--- a/wolkenatlas/constants.py
+++ b/wolkenatlas/constants.py
@@ -4,7 +4,10 @@ INVERTED_INDEX_FILENAME = 'inverted_index.pkl'
 
 FILE_TYPE_MAP = {
     '.txt': 'text',
-    '.bin': 'binary'
+    '.bin': 'binary',
+    '.tgz': 'archive',
+    '.tar.gz': 'archive',
+    '.gz': 'archive'
 }
 
 COMPOSITION_FUNCTION_DIM_MULTIPLIER = {

--- a/wolkenatlas/embedding.py
+++ b/wolkenatlas/embedding.py
@@ -75,7 +75,7 @@ class Embedding:
 
             if file_type is None:
                 ext = os.path.splitext(model_file)[1]
-                if ext not in ['.txt', '.bin']:
+                if ext not in ['.txt', '.bin', '.tgz', '.tar.gz', '.gz']:
                     raise ValueError(f'Need to specify "file_type" (e.g. "text" or "binary") if you are not '
                                      f'loading a wolkenatlas file!')
                 else:


### PR DESCRIPTION
supports loading tarred & gzed kvec files, i.e. if you archive a kvec file with `tar -cvzf embeddings.kvec.tgz embeddings.kvec`, wolkenatlas can now read directly from the archived data.