### PR TITLE
Use JSON serialization format instead of Pickle

### DIFF
--- a/wolkenatlas/constants.py
+++ b/wolkenatlas/constants.py
@@ -1,6 +1,6 @@
 VECTORS_FILENAME_HDF = 'X.hdf'
 VECTORS_FILENAME_NPY = 'X.npy'
-INVERTED_INDEX_FILENAME = 'inverted_index.pkl'
+INVERTED_INDEX_FILENAME = 'inverted_index.json'
 
 FILE_TYPE_MAP = {
     '.txt': 'text',

--- a/wolkenatlas/embedding.py
+++ b/wolkenatlas/embedding.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Any, Dict, List, Union
 import logging
 import os
@@ -67,8 +66,8 @@ class Embedding:
         emb = Embedding._empty()
 
         if data_processing.check_is_wolkenatlas(model_file):
-            emb.inverted_index_ = file_processing.load_pickle(os.path.join(model_file,
-                                                                           constants.INVERTED_INDEX_FILENAME))
+            emb.inverted_index_ = file_processing.load_json(os.path.join(model_file,
+                                                                         constants.INVERTED_INDEX_FILENAME))
             emb.vector_space_ = file_processing.load_vector_space(model_file)
         else:
             file_type = kwargs.pop('file_type', None)
@@ -148,7 +147,7 @@ class Embedding:
             os.makedirs(filename)
 
         file_processing.save_vector_space(self.vector_space_, filename, use_hdf)
-        file_processing.save_pickle(self.inverted_index_, os.path.join(filename, constants.INVERTED_INDEX_FILENAME))
+        file_processing.save_json(self.inverted_index_, os.path.join(filename, constants.INVERTED_INDEX_FILENAME))
 
     def word2index(self, word, oov=-1):
         return self.inverted_index_.get(word, oov)

--- a/wolkenatlas/util/data_processing.py
+++ b/wolkenatlas/util/data_processing.py
@@ -1,6 +1,6 @@
+import json
 import logging
 import os
-import pickle
 import tarfile
 
 import numpy as np
@@ -41,7 +41,7 @@ def load_archive_file(filename, expected_dim=-1, buffer_offset=128, dtype=np.flo
             if tar_info.isreg():
                 if tar_info.name.endswith(constants.INVERTED_INDEX_FILENAME):
                     content = tar.extractfile(tar_info.name)
-                    inv_idx = pickle.load(content)
+                    inv_idx = json.load(content)
                 if tar_info.name.endswith(constants.VECTORS_FILENAME_NPY):
                     content = tar.extractfile(tar_info.name)
                     space = np.frombuffer(content.read(), dtype=dtype, offset=buffer_offset)

--- a/wolkenatlas/util/file_processing.py
+++ b/wolkenatlas/util/file_processing.py
@@ -1,22 +1,20 @@
+import json
 import logging
 import os
-import pickle
 
 import numpy as np
 
 from wolkenatlas import constants
 
 
-def load_pickle(filename):
-    with open(filename, 'rb') as in_file:
-        inv_idx = pickle.load(in_file)
-
-    return inv_idx
+def load_json(path: str):
+    with open(path) as file:
+        return json.load(file)
 
 
-def save_pickle(inv_idx, filename):
-    with open(filename, 'wb') as out_file:
-        pickle.dump(inv_idx, out_file)
+def save_json(obj, path: str):
+    with open(path, 'wb') as out_file:
+        json.dump(obj, out_file)
 
 
 def save_array(obj, filename):

--- a/wolkenatlas/util/file_processing.py
+++ b/wolkenatlas/util/file_processing.py
@@ -13,7 +13,7 @@ def load_json(path: str):
 
 
 def save_json(obj, path: str):
-    with open(path, 'wb') as out_file:
+    with open(path, 'w') as out_file:
         json.dump(obj, out_file)
 
 


### PR DESCRIPTION
This PR proposes to use JSON format instead of Pickle. This format allows easier inspection of the saved data, it's standartized and would allow to deserialize the artifacts with other programming languages.