### PR TITLE
Feature/handle multi key requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wolkenatlas"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   { name="Thomas Kober", email="tttthomasssss@gmail.com" },
 ]

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
 	# Versions should comply with PEP440.  For a discussion on single-sourcing
 	# the version across setup.py and the project code, see
 	# https://packaging.python.org/en/latest/single_source_version.html
-	version='0.2.0',
+	version='0.2.1',
 
 	description='NLP embedding wrapper',
 	long_description=long_description,

--- a/wolkenatlas/embedding.py
+++ b/wolkenatlas/embedding.py
@@ -1,6 +1,7 @@
-from typing import Any, Dict, List, Union
 import logging
+import operator
 import os
+from typing import Any, Dict, List, Union
 
 import numpy as np
 
@@ -152,30 +153,42 @@ class Embedding:
     def _getitem_multi_embeddings(self, word, default=None):
         default = default or self.oov_
 
-        if word not in self.inverted_index_:
-            d = {
+        multi_key_request = isinstance(word, tuple)
+        if not multi_key_request and word not in self.inverted_index_:
+            data = {
                 constants.INPUT_IDS_KEY: default,
                 constants.ATTENTION_MASK_KEY: default
             }
             if self.vector_space_.shape[-1] == 3:
-                d[constants.TOKEN_TYPE_IDS_KEY] = default
-            return d
+                data[constants.TOKEN_TYPE_IDS_KEY] = default
+            return data
 
-        word_idx = self.inverted_index_[word]
-        d = {
+        if multi_key_request:
+            word_idx = np.array(operator.itemgetter(*word)(self.inverted_index_))
+        else:
+            word_idx = self.inverted_index_[word]
+
+        data = {
             constants.INPUT_IDS_KEY: self.vector_space_[word_idx, :, constants.INPUT_IDS_INDEX],
             constants.ATTENTION_MASK_KEY: self.vector_space_[word_idx, :, constants.ATTENTION_MASK_INDEX]
         }
         if self.vector_space_.shape[-1] == 3:
-            d[constants.TOKEN_TYPE_IDS_KEY] = self.vector_space_[word_idx, :, constants.TOKEN_TYPE_IDS_INDEX]
+            data[constants.TOKEN_TYPE_IDS_KEY] = self.vector_space_[word_idx, :, constants.TOKEN_TYPE_IDS_INDEX]
 
-        return d
+        return data
 
     def _getitem_single_embedding(self, word, default=None):
         default = default or self.oov_
 
-        if word not in self.inverted_index_:
+        multi_key_request = isinstance(word, tuple)
+
+        if not multi_key_request and word not in self.inverted_index_:
             return default
+
+        if multi_key_request:
+            word_idx = np.array(operator.itemgetter(*word)(self.inverted_index_))
+        else:
+            word_idx = self.inverted_index_[word]
 
         return self.vector_space_[self.inverted_index_[word]]
     @property

--- a/wolkenatlas/embedding.py
+++ b/wolkenatlas/embedding.py
@@ -190,7 +190,8 @@ class Embedding:
         else:
             word_idx = self.inverted_index_[word]
 
-        return self.vector_space_[self.inverted_index_[word]]
+        return self.vector_space_[word_idx]
+    
     @property
     def dimensionality(self):
         return self.dimensionality_


### PR DESCRIPTION
This PR enables the request of multiple keys for an embedding, for example:
```python
from wolkenatlas import Embedding

emb = Embedding.from_file("...")
X = emb["the", "cat", "sat", "on", "the", "mat"]
```
will return a `6x300` `np.ndarray` (supposing 300dim word embeddings).

It can't handle OOVs, so if one of the items is OOV the whole thing will crash loudly.