### PR TITLE
Feature/index lookup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wolkenatlas"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
   { name="Thomas Kober", email="tttthomasssss@gmail.com" },
 ]
 description = "NLP embedding wrapper"
 readme = "Readme.md"
 license = { file="LICENSE" }
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
 	# Versions should comply with PEP440.  For a discussion on single-sourcing
 	# the version across setup.py and the project code, see
 	# https://packaging.python.org/en/latest/single_source_version.html
-	version='0.2.1',
+	version='0.2.2',
 
 	description='NLP embedding wrapper',
 	long_description=long_description,
@@ -55,10 +55,10 @@ setup(
 
 		# Specify the Python versions you support here. In particular, ensure
 		# that you indicate whether you support Python 2, Python 3 or both.
-		'Programming Language :: Python :: 3.6',
-		'Programming Language :: Python :: 3.7',
 		'Programming Language :: Python :: 3.8',
 		'Programming Language :: Python :: 3.9',
+		'Programming Language :: Python :: 3.10',
+		'Programming Language :: Python :: 3.11',
 	],
 
 	# What does your project relate to?


### PR DESCRIPTION
This PR enables an index lookup inside `__getitem__`:
```python
from wolkenatlas import Embedding
import numpy as np

emb = Embedding.from_file("...")
idx = np.array([3, 4, 43])
emb[idx]
```
This now gives the same result as accessing by keys. OOVs are not handled and indices out of bounds will crash loudly.

This PR furthermore drops support for py3.6 and py3.7.