### PR TITLE
Feature/enable list based multi key requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.pyc
 .idea/*
 # Byte-compiled / optimized / DLL files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wolkenatlas"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
   { name="Thomas Kober", email="tttthomasssss@gmail.com" },
 ]

--- a/wolkenatlas/embedding.py
+++ b/wolkenatlas/embedding.py
@@ -173,7 +173,7 @@ class Embedding:
     def _getitem_multi_embeddings(self, word, default=None):
         default = default or self.oov_
 
-        multi_key_request = isinstance(word, tuple)
+        multi_key_request = isinstance(word, (tuple, list))
         if not multi_key_request and word not in self.inverted_index_:
             data = {
                 constants.INPUT_IDS_KEY: default,
@@ -200,7 +200,7 @@ class Embedding:
     def _getitem_single_embedding(self, word, default=None):
         default = default or self.oov_
 
-        multi_key_request = isinstance(word, tuple)
+        multi_key_request = isinstance(word, (tuple, list))
 
         if not multi_key_request and word not in self.inverted_index_:
             return default


### PR DESCRIPTION
Enables multi key requests for embeddigs

Example:
```python
import numpy as np
from wolkenatlas import Embedding

X = np.array([[1, 2, 3], [3, 2, 1], [2, 2, 2], [3, 3, 3], [1, 1, 1], [0, 0, 0]])
inv_idx = {"a": 0, "b": 1, "c": 2, "d": 3, "e": 4, "f": 5}
emb = Embedding(vector_space=X, inverted_index=inv_idx)

# This has already been working
emb[("a", "b")] # <-- Note that the key is a tuple of words

'''Returns
array([[1, 2, 3],
       [3, 2, 1]])

'''

# This is _now_ also working:
emb[["a", "b"]] # <-- Note that the key is a _list_ of words

'''Returns
array([[1, 2, 3],
       [3, 2, 1]])
'''
```